### PR TITLE
chore(rules): add commit scope and completion discipline

### DIFF
--- a/.cursor/rules/project-standards.mdc
+++ b/.cursor/rules/project-standards.mdc
@@ -52,3 +52,10 @@ alwaysApply: true
 - AI agents must **NEVER** perform self-review approvals on pull requests they authored or updated.
 - AI agents must **NEVER** merge pull requests unless the user explicitly requests the merge in the current conversation.
 - Even when merge is explicitly requested, AI agents must not bypass required checks, required reviews, or branch protection rules.
+
+## 9) Commit Scope and Completion Discipline
+
+- **NEVER** modify files outside the explicit user request or agreed scope. If unexpected or unrelated changes are required, stop and ask for confirmation first.
+- Unless the user explicitly requests otherwise, all intended changes in the current task scope must be committed before finishing the task.
+- Before any commit, review changed files and confirm intent. Any unintentionally changed file must be called out to the user before commit.
+- Before creating or updating a PR, run a final working-tree check (`git status --short` and `git diff --staged`) to ensure no accidental omissions or unintended files remain.

--- a/.cursor/rules/project-standards.mdc
+++ b/.cursor/rules/project-standards.mdc
@@ -59,3 +59,9 @@ alwaysApply: true
 - Unless the user explicitly requests otherwise, all intended changes in the current task scope must be committed before finishing the task.
 - Before any commit, review changed files and confirm intent. Any unintentionally changed file must be called out to the user before commit.
 - Before creating or updating a PR, run a final working-tree check (`git status --short` and `git diff --staged`) to ensure no accidental omissions or unintended files remain.
+
+## 10) Merged PR Immutability
+
+- **NEVER** attempt to add commits to a pull request that is already merged or closed.
+- Before any push intended for an existing PR, verify the PR state is open. If the PR is merged/closed, create a new branch and a new PR instead.
+- If uncertain which PR is active for a branch, check explicitly and confirm with the user before pushing.

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -7,6 +7,15 @@
 
 ---
 
+## コミット漏れ防止ルールの追加
+
+**Timestamp**: 2026-04-28T20:54:00+09:00
+**User Input**: "追加してプッシュして"
+**AI Response**: "`.cursor/rules/project-standards.mdc` に『Commit Scope and Completion Discipline』を追加。依頼外変更の禁止、原則コミット完了、コミット前の意図確認、PR前の最終 `git status`/`git diff --staged` 確認を明文化。"
+**Context**: Governance - Commit hygiene and scope control
+
+---
+
 ## CI lint ジョブを差分lintへ調整
 
 **Timestamp**: 2026-04-28T20:43:00+09:00

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -7,6 +7,15 @@
 
 ---
 
+## マージ済みPR誤追記防止ルールの追加
+
+**Timestamp**: 2026-04-28T20:59:00+09:00
+**User Input**: "マージ済みのPRに反映しようとするようなミスを防ぐためのルールを追加。"
+**AI Response**: "`.cursor/rules/project-standards.mdc` に『Merged PR Immutability』を追加し、(1) マージ済み/クローズ済みPRへの追記禁止、(2) push前のPRオープン状態確認、(3) 不明時の明示確認をルール化。"
+**Context**: Governance - PR lifecycle safety
+
+---
+
 ## コミット漏れ防止ルールの追加
 
 **Timestamp**: 2026-04-28T20:54:00+09:00


### PR DESCRIPTION
## Summary
- Add explicit rule to stop out-of-scope file changes unless confirmed by the user
- Add rule to commit intended in-scope changes before finishing a task unless user says otherwise
- Add mandatory pre-commit intent check and pre-PR final `git status --short` / `git diff --staged` verification

## Test plan
- [x] Rule file update reviewed
- [x] Scope of this PR limited to rule and audit files


Made with [Cursor](https://cursor.com)