### PR TITLE
fix(ci): remove main assumption from lint diff base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ github.base_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -22,8 +24,8 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: git fetch origin main --depth=1
-      - run: pnpm lint-staged --diff="origin/main...HEAD"
+      - run: git fetch origin "$BASE_REF" --depth=1
+      - run: pnpm lint-staged --diff="origin/$BASE_REF...HEAD"
 
   test:
     name: test


### PR DESCRIPTION
## Summary
- Use dynamic base ref (`github.base_ref || github.ref_name`) in CI lint job
- Replace hardcoded `origin/main...HEAD` diff with `origin/$BASE_REF...HEAD`
- Keep trigger definitions unchanged while removing runtime main assumptions

## Test plan
- [x] Local pre-push `pnpm test`
- [x] Confirm CI lint job succeeds on this PR

Made with [Cursor](https://cursor.com)