### PR TITLE
chore(cursor): add slash commands for sync and PR creation

### DIFF
--- a/.cursor/commands/main-sync.md
+++ b/.cursor/commands/main-sync.md
@@ -1,0 +1,12 @@
+mainブランチへ切り替えて最新化
+
+以下を順番に実行してください。
+
+```bash
+git switch main
+git fetch origin main
+git pull --ff-only origin main
+git status -sb
+```
+
+失敗した場合は、どのコマンドで失敗したかとエラーメッセージをそのまま報告してください。

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -1,0 +1,29 @@
+PR作成
+
+以下を順番に実行してください。
+
+```bash
+current_branch="$(git branch --show-current)"
+if [ "$current_branch" = "main" ] || [ "$current_branch" = "develop" ] || [ "$current_branch" = "staging" ]; then
+  # 変更内容から conventional branch 名を決める
+  changed_files="$(git diff --name-only)"
+  if [ -z "$changed_files" ]; then
+    changed_files="$(git diff --name-only --cached)"
+  fi
+  scope="$(printf "%s\n" "$changed_files" | head -n 1 | cut -d'/' -f1 | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9-')"
+  if [ -z "$scope" ]; then
+    scope="update"
+  fi
+  new_branch="chore/${scope}-$(date +%Y%m%d-%H%M)"
+  echo "現在ブランチは $current_branch です。作業内容からブランチ名を生成: $new_branch"
+  git switch -c "$new_branch"
+fi
+
+git status -sb
+git diff
+git log --oneline -10
+gh pr create
+```
+
+`gh pr create` は対話形式で、タイトルと本文は今回の変更内容に合わせて入力してください。  
+既存PRがある場合は新規作成せず、そのPR URLを表示してください。


### PR DESCRIPTION
## Summary
- Add `/main-sync` command to switch to `main` and fast-forward update
- Add `/pr` command to guide branch creation and PR creation flow
- Standardize command descriptions to render cleanly in command list

## Test plan
- [x] Trigger `/main-sync` command and verify main sync
- [x] Trigger `/pr` command and verify branch creation flow on main

Made with [Cursor](https://cursor.com)