### PR TITLE
chore(cursor): add slash commands for git workflows

### DIFF
--- a/.cursor/commands/main-sync.md
+++ b/.cursor/commands/main-sync.md
@@ -1,0 +1,12 @@
+main ブランチへ切り替えて最新化する
+
+以下を順番に実行:
+
+```bash
+git switch main
+git fetch origin main
+git pull --ff-only origin main
+git status -sb
+```
+
+失敗した場合は、失敗したコマンドとエラーメッセージをそのまま報告する。

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -1,0 +1,13 @@
+PR作成
+
+次に AI が以下を実行してください。
+
+1. 現在ブランチが `main` / `develop` / `staging` の場合のみ、変更差分を要約して Conventional Branch 形式 (`type/slug`) の候補を1つ提案する
+   - `type`: `feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert`
+2. `main` / `develop` / `staging` の場合のみ、ユーザーに「このブランチ名で作成してよいか」を確認する（yes/no）
+3. `main` / `develop` / `staging` の場合のみ、yes なら提案名、no ならユーザー指定名でブランチ作成する
+4. それ以外のブランチでは、ブランチ提案・作成は行わず現在ブランチのまま進める
+5. 変更内容を確認し、必要なファイルを `git add` する
+6. 変更の意図に沿ったコミットメッセージを作成して `git commit` する
+7. `git push -u origin HEAD` で現在ブランチをpushする
+8. 変更内容を要約してタイトル/本文を作成し、`gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"` 形式で新規PRを作成する


### PR DESCRIPTION
## Summary
- Add `/main-sync` command to switch to `main` and fast-forward latest changes
- Add `/pr` command guidance for AI-led branch proposal and PR flow
- Keep command descriptions as plain text so command list displays cleanly

## Test plan
- [x] Run `/main-sync` successfully
- [x] Run `/pr` precheck and branch proposal flow

Made with [Cursor](https://cursor.com)