### PR TITLE
feat: US-006 API補足を追加（写真リプライ精算テキスト）

### DIFF
--- a/docs/specs/docs/ja/1.0.0/api/design/postReceiptExpenseAssistFromSlackReply.md
+++ b/docs/specs/docs/ja/1.0.0/api/design/postReceiptExpenseAssistFromSlackReply.md
@@ -1,0 +1,73 @@
+---
+title: 写真リプライ受信による精算テキスト生成（内部イベント）
+description: Slack 写真リプライを受信し、親スレッドへ経費精算テキストを返信する内部 API（US-006）
+---
+
+# 写真リプライ受信による精算テキスト生成（内部イベント）
+
+## エンドポイント
+
+- `POST /internal/slack/events/receipt-reply`
+
+## operationId
+
+- `postReceiptExpenseAssistFromSlackReply`
+
+## 概要
+
+Slack のイベント連携から「写真付きリプライ」を受信し、対象スレッドの文脈を検証して経費精算入力向けテキストを生成・返信する。公開 API ではなく **内部イベント受信用** のエンドポイント。
+
+## 処理境界（US-006）
+
+- 本 API の責務:
+  - 写真付きリプライかどうかの判定
+  - 親メッセージへの画像反映（または画像参照更新）
+  - 精算入力用テキストの生成と 1 回返信
+  - 冪等性（同一イベント重複受信の抑止）
+- 本 API の対象外:
+  - 経費申請 SaaS への本登録・送信
+  - マッチング結果そのものの再計算・再編成
+
+## リクエスト
+
+| フィールド | 型 | 必須 | 説明 |
+| ---------- | -- | ---- | ---- |
+| `eventId` | `string` | はい | Slack イベントの一意 ID（冪等キー） |
+| `channelId` | `string` | はい | 対象チャンネル ID |
+| `threadTs` | `string` | はい | 親スレッド TS |
+| `replyTs` | `string` | はい | リプライメッセージ TS |
+| `replyUserId` | `string` | はい | リプライ投稿者の Slack ユーザー ID |
+| `imageFileIds` | `string[]` | はい | 添付画像ファイル ID。1 件以上必須 |
+| `occurredAt` | `string` (`date-time`) | いいえ | 受信イベント発生時刻 |
+
+## レスポンス（例）
+
+`202` — 非同期受理（返信投稿までを同一処理で完了）
+
+```json
+{
+  "status": "accepted",
+  "eventId": "Ev03ABCD1234",
+  "expenseReplyTs": "1745820011.123456",
+  "alreadyProcessed": false
+}
+```
+
+`alreadyProcessed: true` は重複受信時に副作用を再実行しなかったケース。
+
+## エラー
+
+| HTTP | 条件 |
+| ---- | ---- |
+| `400` | `imageFileIds` が空、または写真添付なし |
+| `409` | `eventId` が既処理（冪等性により拒否） |
+| `422` | 対象スレッドが精算テキスト生成条件を満たさない |
+| `500` | Slack API / 画像取得 / テキスト生成処理の内部エラー |
+
+## OpenAPI
+
+- 本仕様の path / `operationId` は [`openapi-app.yml`](../../../../public/openapi/openapi-app.yml) に反映する。
+
+## 関連
+
+- ユーザーストーリー: [US-006](../../user-stories/us-006.md)

--- a/docs/specs/docs/ja/1.0.0/user-stories/us-006.md
+++ b/docs/specs/docs/ja/1.0.0/user-stories/us-006.md
@@ -60,3 +60,10 @@ notes:
 ## 補足
 
 <UserStoryPage section="notes" />
+
+## Application Design トレース
+
+| 区分 | 参照 |
+| ---- | ---- |
+| API（内部イベント） | [postReceiptExpenseAssistFromSlackReply](../api/design/postReceiptExpenseAssistFromSlackReply.md) / `operationId: postReceiptExpenseAssistFromSlackReply` |
+| OpenAPI | [`openapi-app.yml`](../../../public/openapi/openapi-app.yml) |

--- a/docs/specs/docs/public/openapi/openapi-app.yml
+++ b/docs/specs/docs/public/openapi/openapi-app.yml
@@ -3,7 +3,62 @@ info:
   title: Luncher API
   version: 1.0.0
 components:
-  schemas: {}
+  schemas:
+    ReceiptReplyEventRequest:
+      type: object
+      properties:
+        eventId:
+          type: string
+        channelId:
+          type: string
+        threadTs:
+          type: string
+        replyTs:
+          type: string
+        replyUserId:
+          type: string
+        imageFileIds:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        occurredAt:
+          type: string
+          format: date-time
+      required:
+        - eventId
+        - channelId
+        - threadTs
+        - replyTs
+        - replyUserId
+        - imageFileIds
+    ReceiptReplyEventAccepted:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - accepted
+        eventId:
+          type: string
+        expenseReplyTs:
+          type: string
+        alreadyProcessed:
+          type: boolean
+      required:
+        - status
+        - eventId
+        - alreadyProcessed
+    ApiError:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
   parameters: {}
 paths:
   /health:
@@ -25,4 +80,47 @@ paths:
                       - ok
                 required:
                   - status
+  /internal/slack/events/receipt-reply:
+    post:
+      operationId: postReceiptExpenseAssistFromSlackReply
+      tags:
+        - slack-events
+      summary: 写真付き Slack リプライを受信し精算テキスト返信を行う
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReceiptReplyEventRequest"
+      responses:
+        "202":
+          description: Event accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReceiptReplyEventAccepted"
+        "400":
+          description: Invalid request (e.g., no image attached)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: Duplicate event
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Story precondition not satisfied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          description: Internal processing error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
 webhooks: {}


### PR DESCRIPTION
## Summary
- US-006 向けに Slack 写真リプライ受信 API の設計書を `api/design` に追加
- `openapi-app.yml` に `postReceiptExpenseAssistFromSlackReply` を追加し request/response/error を定義
- `us-006.md` に Application Design トレースを追記して API 設計との参照を明確化

## Test plan
- [x] ドキュメント差分レビュー
- [x] OpenAPI パス/operationId の整合確認
- [x] 関連成果物リンクの整合確認

Closes #69

Made with [Cursor](https://cursor.com)