### PR TITLE
US-002 Sub-01: API補足（api/design）作成

### DIFF
--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -7,6 +7,101 @@
 
 ---
 
+## Issue #46: US-002 Sub-01 API補足
+
+**Timestamp**: 2026-04-28T23:51:36+09:00
+**User Input**: "<cursor_commands>
+--- Cursor Command: worktree ---
+Run task in a separate git worktree.
+
+**Optional argument:** If the user wrote `/worktree branch=<git-ref>` or `/worktree <branch=<git-ref>>`, use that ref as `WORKTREE_START_REF` (any commit-ish Git accepts: branch name, tag, full SHA, `origin/main`, etc.). Before the create block: Unix/macOS `export WORKTREE_START_REF='<git-ref>'`; Windows PowerShell `$env:WORKTREE_START_REF = '<git-ref>'`. If omitted, the script defaults to `HEAD`.
+
+Only do this if the user invoked `/worktree` or explicitly asked for a git worktree in this chat. On first touch for a repo, run the create block once with shell `working_directory` set to that repo's workspace folder, record `workspace folder -> REPO_ROOT -> WORKTREE_PATH`, and then use that `WORKTREE_PATH` for all later reads, edits, shell, and repo-local git in that repo until the user says to stop or uses `/apply-worktree` / `/delete-worktree`. Do not fall back to `REPO_ROOT` while that mapping exists.
+
+Multi-root: keep one chat-wide mapping, reuse it if two workspace folders share a repo, and create at most one worktree per `REPO_ROOT` unless the user explicitly asks for another.
+
+Use the create blocks below; do not hand-roll a different flow. Shared id: filesystem-safe `<NAME>` + random 8-char lowercase hex `<SUFFIX>` -> `WORKTREE_ID=<NAME>-<SUFFIX>` used for every repo in this chat.
+
+Unix/macOS (multi-repo safe: each repo gets its own subfolder under `~/.cursor/worktrees/<WORKTREE_ID>/`):
+```bash
+set -euo pipefail
+WORKTREE_ID=\"<NAME>-<SUFFIX>\"
+REPO_ROOT=\"$(git rev-parse --show-toplevel)\"
+REPO_BASENAME=\"$(basename \"$REPO_ROOT\")\"
+if command -v shasum >/dev/null 2>&1; then
+  REPO_HASH=\"$(printf '%s' \"$REPO_ROOT\" | shasum -a 256 | cut -c1-12)\"
+else
+  REPO_HASH=\"$(printf '%s' \"$REPO_ROOT\" | sha256sum | cut -c1-12)\"
+fi
+REPO_KEY=\"${REPO_BASENAME}-${REPO_HASH}\"
+WORKTREE_SET_DIR=\"$HOME/.cursor/worktrees/$WORKTREE_ID\"
+WORKTREE_DIR=\"$WORKTREE_SET_DIR/$REPO_KEY\"
+mkdir -p \"$WORKTREE_SET_DIR\"
+if [ -d \"$WORKTREE_DIR\" ]; then echo \"ERROR: worktree directory already exists: $WORKTREE_DIR\" >&2; exit 1; fi
+WORKTREE_START_REF=\"${WORKTREE_START_REF:-HEAD}\"
+git worktree add --detach \"$WORKTREE_DIR\" \"$WORKTREE_START_REF\"
+HEAD_COMMIT=\"$(git -C \"$WORKTREE_DIR\" rev-parse HEAD)\"
+echo \"WORKTREE_ID=$WORKTREE_ID\"
+echo \"REPO_KEY=$REPO_KEY\"
+echo \"WORKTREE_PATH=$WORKTREE_DIR\"
+echo \"REPO_ROOT=$REPO_ROOT\"
+echo \"HEAD_COMMIT=$HEAD_COMMIT\"
+echo \"WORKTREE_START_REF=$WORKTREE_START_REF\"
+```
+
+Windows (PowerShell; one worktree path per WORKTREE_ID—use a distinct WORKTREE_ID per repo if you work in multiple repos):
+```powershell
+$ErrorActionPreference = 'Stop'
+$Name = \"<NAME>-<SUFFIX>\"
+$RepoRoot = (git rev-parse --show-toplevel).Trim()
+$WorktreeDir = Join-Path $env:USERPROFILE \".cursor\\worktrees\\$Name\"
+if (Test-Path $WorktreeDir) { Write-Error \"ERROR: worktree directory already exists: $WorktreeDir\"; exit 1 }
+$WorktreeStartRef = if ($env:WORKTREE_START_REF) { $env:WORKTREE_START_REF } else { \"HEAD\" }
+git worktree add --detach $WorktreeDir $WorktreeStartRef
+$HeadCommit = (git -C $WorktreeDir rev-parse HEAD).Trim()
+Write-Output \"WORKTREE_ID=$Name\"
+Write-Output \"WORKTREE_PATH=$WorktreeDir\"
+Write-Output \"REPO_ROOT=$RepoRoot\"
+Write-Output \"HEAD_COMMIT=$HeadCommit\"
+Write-Output \"WORKTREE_START_REF=$WorktreeStartRef\"
+```
+
+After creation, machine-readable lines include:
+```text
+WORKTREE_ID=<shared id>
+REPO_KEY=<repo-specific key; Unix only>
+WORKTREE_PATH=<absolute path>
+REPO_ROOT=<absolute repo root>
+HEAD_COMMIT=<sha>
+WORKTREE_START_REF=<ref used for git worktree add; HEAD if omitted>
+```
+
+**Setup is not optional to *check*; only optional to *run* when no config applies.** Immediately after each successful `git worktree add`, and before any other reads, edits, shell, or git against `WORKTREE_PATH`, you MUST complete the setup discovery and execution step below. Do not start task work, open files for editing, or run installs in the worktree until this step is done or you have explicitly verified there is nothing to run.
+
+1. Search for `.cursor/worktrees.json` in `REPO_ROOT`, then `WORKTREE_PATH`. You must actually perform this lookup on disk for each new worktree (do not assume \"no config\" from memory or prior sessions). If a file exists at either path, use it to determine setup (if both exist, prefer the copy under `WORKTREE_PATH` when it defines `setup-worktree*` / `setup-worktree` keys; otherwise use `REPO_ROOT`).
+2. If a config file exists and defines a setup for this OS, you MUST run it exactly once for this worktree. Prefer `setup-worktree-unix` / `setup-worktree-windows` when those keys exist; otherwise `setup-worktree` (string = one shell command, array = run commands in order). Resolve script paths relative to the config file's directory; execute with shell cwd = `WORKTREE_PATH` and export `ROOT_WORKTREE_PATH=<REPO_ROOT>`.
+3. You may skip running commands only when: no `.cursor/worktrees.json` exists in either location, or the file(s) exist but contain no applicable setup keys for this platform. You MUST NOT skip because you assume dependencies are already installed or the repo \"looks ready\".
+
+Keep for the chat (update as you add repos):
+```text
+workspace folder -> repo root -> worktree path
+```
+
+Setup failure -> stop and report. Do not switch branches or change the main working tree.
+
+End: report shared `WORKTREE_ID` and each `WORKTREE_PATH`, `REPO_ROOT`, `HEAD_COMMIT`, and `WORKTREE_START_REF`; state whether worktree setup ran, was skipped after checking both paths, or failed. Tell the user merge-back is `/apply-worktree` (per repo) and cleanup is `/delete-worktree` (full scripts there).
+
+--- End Command ---
+</cursor_commands>
+
+Handle issue #46 (US-002 Sub-01: API補足 api/design 作成・更新) in /workspace.
+Complete only this sub-issue in isolated worktree: implement API design supplement for US-002, commit, push, PR, comment issue, set status:in-review.
+Return changed files, commit SHA, PR URL, and issue label update result."
+**AI Response**: "隔離 worktree を作成し、US-002 の API 補足を `api/design` に新規追加。`us-002.md` にトレースを追記し、作業計画チェックを進捗更新。続けて commit/push/PR 作成、issue コメント、ラベル更新を実施。"
+**Context**: Worktree task execution - Issue #46
+
+---
+
 ## マージ済みPR誤追記防止ルールの追加
 
 **Timestamp**: 2026-04-28T20:59:00+09:00

--- a/aidlc-docs/inception/plans/application-design-by-us.md
+++ b/aidlc-docs/inception/plans/application-design-by-us.md
@@ -38,11 +38,11 @@
 - [ ] 重複投稿抑止・ログ要件の反映を確認
 
 ### us-002（参加表明）
-- [ ] API 補足（`api/design`）を作成・更新
+- [x] API 補足（`api/design`）を作成・更新
 - [ ] OpenAPI（`public/openapi/openapi-app.yml`）と operationId を整合
 - [ ] DB 設計（CDM/PDM）を作成・更新
 - [ ] 締切判定・月次上限（1名あたり月2回）を反映
-- [ ] `us-002.md` に関連成果物トレースを追記
+- [x] `us-002.md` に関連成果物トレースを追記
 
 ### us-003（マッチング）
 - [ ] バッチ設計（`batch/design`）を作成・更新

--- a/docs/specs/docs/ja/1.0.0/api/design/postLunchEntryReaction.md
+++ b/docs/specs/docs/ja/1.0.0/api/design/postLunchEntryReaction.md
@@ -1,0 +1,81 @@
+---
+title: 参加表明受付（Slackリアクション）
+description: Slack リアクションイベントを受けて、当日参加者を登録・解除する API（US-002）
+---
+
+# 参加表明受付（Slackリアクション）
+
+## エンドポイント
+
+- `POST /internal/events/lunch-entry-reaction`
+
+## operationId
+
+- `postLunchEntryReaction`
+
+## 概要
+
+Slack の募集メッセージに対するリアクション追加/解除イベントを受け取り、当日ランチの参加対象を更新する内部 API。  
+US-002 の対象は **参加表明受付まで** であり、グループ編成（US-003）は対象外。
+
+## 認証・不正呼び出し防止
+
+- Slack 署名検証（`X-Slack-Signature`, `X-Slack-Request-Timestamp`）を必須とする。
+- さらに内部向け API Gateway 制御（IP 制限や mTLS など）を適用して多層防御する。
+
+## リクエスト
+
+| フィールド | 型 | 必須 | 説明 |
+| ---------- | -- | -- | ---- |
+| `eventId` | `string` | はい | イベント重複抑止用キー（Slack Event ID） |
+| `eventType` | `string` | はい | `reaction_added` または `reaction_removed` |
+| `reaction` | `string` | はい | 対象リアクション名（参加表明用） |
+| `lunchDate` | `string` (date) | はい | 対象日（JST） |
+| `slackUserId` | `string` | はい | 参加者の Slack User ID |
+| `channelId` | `string` | はい | 募集メッセージのチャンネル ID |
+| `messageTs` | `string` | はい | 募集メッセージの ts |
+| `occurredAt` | `string` (date-time) | はい | Slack 上での発生時刻 |
+
+## 業務ルール
+
+1. 締切後のイベントは `rejected` として受理し、参加状態は変更しない。
+2. 月次上限（1名あたり月2回）超過時は `rejected` として受理し、参加状態は変更しない。
+3. `reaction_added` は冪等に扱い、既登録なら `no_change` を返す。
+4. `reaction_removed` は既存参加を取り消し、未登録なら `no_change` を返す。
+
+## レスポンス（例）
+
+`200` - 正常にイベントを処理（更新あり/なし、拒否含む）
+
+```json
+{
+  "status": "ok",
+  "result": "accepted",
+  "lunchDate": "2026-04-28",
+  "slackUserId": "U12345678",
+  "attendanceStatus": "joined"
+}
+```
+
+`result` は次のいずれか:
+- `accepted`（参加状態を更新）
+- `no_change`（冪等処理で変更なし）
+- `rejected`（締切/上限等で不受理）
+
+## エラー
+
+| HTTP | 条件 |
+| ---- | ---- |
+| `400` | 必須項目欠落、`eventType` 不正 |
+| `401` / `403` | 署名検証失敗・内部認可失敗 |
+| `409` | 同一 `eventId` の競合（重複処理） |
+| `500` | DB 更新失敗などの内部エラー |
+
+## OpenAPI
+
+- path と `operationId` は [`openapi-app.yml`](../../../../public/openapi/openapi-app.yml) と整合させる。
+
+## 関連
+
+- ユーザーストーリー: [US-002](../../user-stories/us-002.md)
+- 先行仕様: [US-001 日次案内](./postDailyLunchAnnouncement.md)

--- a/docs/specs/docs/ja/1.0.0/user-stories/us-002.md
+++ b/docs/specs/docs/ja/1.0.0/user-stories/us-002.md
@@ -58,3 +58,12 @@ notes:
 ## 補足
 
 <UserStoryPage section="notes" />
+
+## Application Design トレース
+
+| 区分 | 参照 |
+| ---- | ---- |
+| API（内部イベント） | [postLunchEntryReaction](../api/design/postLunchEntryReaction.md) / `operationId: postLunchEntryReaction` |
+| OpenAPI | [`openapi-app.yml`](../../../public/openapi/openapi-app.yml) |
+| CDM | [概念データモデル（コラボランチ枠）](../database/cdm.md) |
+| PDM | [lunch_dates](../database/pdm/table/lunch_dates)（正本: `luncher-system-design-draft.md` §4） |


### PR DESCRIPTION
## Summary
- US-002（参加表明）向けの API 補足として `postLunchEntryReaction` の設計書を `api/design` に追加
- 参加/解除、重複抑止、締切・月次上限（1名あたり月2回）を API レベルの業務ルールとして明記
- `us-002.md` に Application Design トレースを追記し、参照関係を明確化

## Test plan
- [x] ドキュメント整合性の目視確認
- [x] `ReadLints` で編集ファイルの問題がないことを確認

Closes #46

Made with [Cursor](https://cursor.com)