### PR TITLE
chore(hooks): add branch-name guardrails for Cursor AI

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "bash .cursor/hooks/enforce-conventional-branch.sh",
+        "failClosed": true
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/enforce-conventional-branch.sh
+++ b/.cursor/hooks/enforce-conventional-branch.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -u
+
+/usr/local/bin/node -e '
+const ALLOW = { permission: "allow" };
+let payload = {};
+try {
+  const raw = require("fs").readFileSync(0, "utf8");
+  payload = raw ? JSON.parse(raw) : {};
+} catch {
+  console.log(JSON.stringify(ALLOW));
+  process.exit(0);
+}
+
+const commandText = typeof payload.command === "string" ? payload.command.trim() : "";
+if (!commandText) {
+  console.log(JSON.stringify(ALLOW));
+  process.exit(0);
+}
+
+const pattern = /^(main|master|develop|staging|((feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert)\/[a-z0-9]+(-[a-z0-9]+)*))$/;
+
+let branchName = "";
+
+const checkout = commandText.match(/\bgit checkout -b\s+(\S+)/);
+const sw = commandText.match(/\bgit switch -c\s+(\S+)/);
+const branch = commandText.match(/\bgit branch\s+(\S+)/);
+const gh = commandText.match(/\bgh issue develop\b.*\s--name\s+(\S+)/);
+
+if (checkout) branchName = checkout[1];
+else if (sw) branchName = sw[1];
+else if (branch) branchName = branch[1];
+else if (gh) branchName = gh[1];
+
+branchName = branchName.replace(/^["'\''`]+|["'\''`]+$/g, "");
+
+if (!branchName) {
+  console.log(JSON.stringify(ALLOW));
+  process.exit(0);
+}
+
+if (pattern.test(branchName)) {
+  console.log(JSON.stringify(ALLOW));
+  process.exit(0);
+}
+
+console.log(
+  JSON.stringify({
+    permission: "deny",
+    user_message: `ブランチ名が規約外です: ${branchName}`,
+    agent_message:
+      "Conventional Branch ルール違反。許可: main|master|develop|staging または <type>/<slug>。type は feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert。",
+  })
+);
+'

--- a/.cursor/rules/project-standards.mdc
+++ b/.cursor/rules/project-standards.mdc
@@ -74,3 +74,8 @@ alwaysApply: true
 - Before push/PR, run `pnpm install --frozen-lockfile` at repository root. If it fails, stop and fix consistency before proceeding.
 - For PRs that only change GitHub Actions/tooling, avoid introducing package-manager version drift. Keep CI pnpm version aligned with root `packageManager` unless the user explicitly requests a version change.
 - If lockfile inconsistency is detected in unrelated existing changes, report it clearly to the user and do not mask it with bypasses (`--no-frozen-lockfile`, disabling checks, or weakening required status checks) without explicit approval.
+
+## 12) Script Runtime Policy (Node Only)
+
+- Script execution runtime MUST be Node.js. Prefer `node` or `tsx`-based scripts for automation and hooks.
+- Do NOT introduce new Python-based scripts or Python runtime dependencies for project automation/hooks unless explicitly requested by the user.

--- a/.github/workflows/branch-create-guard.yml
+++ b/.github/workflows/branch-create-guard.yml
@@ -1,0 +1,50 @@
+name: Branch Create Guard
+
+on:
+  create:
+
+jobs:
+  branch-create-guard:
+    if: ${{ github.event.ref_type == 'branch' }}
+    name: branch-create-guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate created branch name
+        id: validate
+        env:
+          BRANCH_NAME: ${{ github.event.ref }}
+        run: |
+          PATTERN='^(main|master|develop|staging|((feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert)/[a-z0-9]+(-[a-z0-9]+)*))$'
+
+          if printf "%s" "$BRANCH_NAME" | grep -Eq "$PATTERN"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+            echo "Branch name is valid: $BRANCH_NAME"
+            exit 0
+          fi
+
+          echo "valid=false" >> "$GITHUB_OUTPUT"
+          echo "Branch name is invalid: $BRANCH_NAME"
+          echo "Allowed: main|master|develop|staging or <type>/<slug>"
+          echo "type: feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert"
+          echo "slug: lowercase letters/numbers and hyphens"
+
+      - name: Delete invalid branch
+        if: ${{ steps.validate.outputs.valid == 'false' }}
+        env:
+          BRANCH_NAME: ${{ github.event.ref }}
+          REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ENCODED_BRANCH="${BRANCH_NAME//\//%2F}"
+          curl --fail-with-body -sS -X DELETE \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/git/refs/heads/$ENCODED_BRANCH"
+
+      - name: Fail workflow for invalid branch
+        if: ${{ steps.validate.outputs.valid == 'false' }}
+        run: |
+          echo "Invalid branch was deleted by policy."
+          exit 1

--- a/.github/workflows/branch-name-guard.yml
+++ b/.github/workflows/branch-name-guard.yml
@@ -1,0 +1,54 @@
+name: Branch Name Guard
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
+      - master
+      - develop
+      - staging
+
+jobs:
+  branch-name-guard:
+    name: branch-name-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch name against conventional policy
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BRANCH_NAME="$HEAD_REF"
+          else
+            BRANCH_NAME="$REF_NAME"
+          fi
+
+          echo "Checking branch: $BRANCH_NAME"
+
+          # Allowed trunk branches.
+          if printf "%s" "$BRANCH_NAME" | grep -Eq '^(main|master|develop|staging)$'; then
+            echo "Allowed protected branch name."
+            exit 0
+          fi
+
+          # Conventional Branch format: <type>/<slug>
+          # type: feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert
+          # slug: lowercase letters/numbers with hyphen-separated segments
+          PATTERN='^(feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert)/[a-z0-9]+(-[a-z0-9]+)*$'
+
+          if printf "%s" "$BRANCH_NAME" | grep -Eq "$PATTERN"; then
+            echo "Branch name is valid."
+            exit 0
+          fi
+
+          echo "Invalid branch name: $BRANCH_NAME"
+          echo "Expected one of:"
+          echo "  - main | master | develop | staging"
+          echo "  - <type>/<slug>"
+          echo "where type is:"
+          echo "  feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert"
+          echo "and slug is lowercase letters/numbers with hyphens."
+          exit 1

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -22,7 +22,7 @@ jobs:
         uses: commit-check/commit-check-action@7c158d4541309c5952de3343151750882b036d10 # v2.6.0
         with:
           message: true
-          branch: true
+          branch: false
           author-name: false
           author-email: false
           job-summary: true

--- a/.husky/check-branch-name.sh
+++ b/.husky/check-branch-name.sh
@@ -7,12 +7,12 @@ if [ "$branch_name" = "HEAD" ] || [ -z "$branch_name" ]; then
   exit 0
 fi
 
-# Conventional Branch 1.0.0 aligned pattern:
-# - trunk: main|master|develop
-# - prefixed: feature|feat|bugfix|fix|hotfix|release|chore
-# - description: lowercase letters/numbers with hyphen-separated segments
-#   and optional dot-separated version-like parts inside each segment.
-pattern='^(main|master|develop|((feature|feat|bugfix|fix|hotfix|release|chore)/[a-z0-9]+(\.[a-z0-9]+)*(-[a-z0-9]+(\.[a-z0-9]+)*)*))$'
+# Conventional Branch policy:
+# - protected: main|master|develop|staging
+# - feature branches: <type>/<slug>
+# - types: feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert
+# - slug: lowercase letters/numbers with hyphen-separated segments
+pattern='^(main|master|develop|staging|((feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert)/[a-z0-9]+(-[a-z0-9]+)*))$'
 
 if printf "%s" "$branch_name" | grep -Eq "$pattern"; then
   exit 0
@@ -20,8 +20,8 @@ fi
 
 echo "Invalid branch name: $branch_name"
 echo "Expected:"
-echo "  main | master | develop"
+echo "  main | master | develop | staging"
 echo "  or <type>/<description>"
-echo "  type: feature|feat|bugfix|fix|hotfix|release|chore"
-echo "  description: lowercase letters/numbers, hyphens, optional dots"
+echo "  type: feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert"
+echo "  description: lowercase letters/numbers and hyphens only"
 exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,1 @@
-pnpm test
+.husky/check-branch-name.sh && pnpm test


### PR DESCRIPTION
## Summary
- add project-level Cursor hook (`beforeShellExecution`) to validate branch names for AI shell commands
- tighten husky branch-name policy to conventional `type/slug` and enforce it on pre-push as well
- add GitHub Actions branch guard workflows and disable duplicate branch checks in `commit-check`

## Test plan
- [x] `pnpm lint:root`
- [x] `pnpm test` (triggered by pre-push hook)
- [x] confirmed PR excludes `docs/specs/docs/ja/1.0.0/api/design/getHealth.md`

Made with [Cursor](https://cursor.com)