### PR TITLE
US-004 Sub-01: API補足 api/design 作成・更新

### DIFF
--- a/aidlc-docs/inception/plans/application-design-by-us.md
+++ b/aidlc-docs/inception/plans/application-design-by-us.md
@@ -54,7 +54,7 @@
 - [ ] `us-003.md` に関連成果物トレースを追記
 
 ### us-004（割当後の欠席）
-- [ ] API 補足（`api/design`）を作成・更新
+- [x] API 補足（`api/design`）を作成・更新
 - [ ] OpenAPI（`public/openapi/openapi-app.yml`）と operationId を整合
 - [ ] DB 設計（CDM/PDM）を作成・更新
 - [ ] Slack 通知差分（通知文面/送信条件）を反映

--- a/docs/specs/docs/ja/1.0.0/api/design/postGroupAbsence.md
+++ b/docs/specs/docs/ja/1.0.0/api/design/postGroupAbsence.md
@@ -1,0 +1,72 @@
+---
+title: 割り当て後の欠席登録 API
+description: US-004（割り当て後の欠席）におけるグループ除外と通知更新を行う API 補足
+---
+
+# 割り当て後の欠席登録 API
+
+## エンドポイント
+
+- `POST /lunches/{lunchId}/groups/absence`
+
+## operationId
+
+- `postGroupAbsence`
+
+## 概要
+
+マッチング済みグループの参加者が欠席リアクションを行った際に、対象メンバーをグループから除外する。除外成功時は更新後のグループ情報を Slack 通知に反映する。
+
+## リクエスト
+
+### Path Parameters
+
+| フィールド | 型 | 必須 | 説明 |
+| ---------- | -- | ---- | ---- |
+| `lunchId` | `string` | はい | 対象ランチ ID |
+
+### Body
+
+| フィールド | 型 | 必須 | 説明 |
+| ---------- | -- | ---- | ---- |
+| `memberSlackUserId` | `string` | はい | 欠席するメンバーの Slack ユーザー ID |
+| `triggerMessageTs` | `string` | はい | 欠席リアクションが付与された元メッセージの Slack TS |
+| `reason` | `string` | いいえ | 任意の欠席理由（監査ログ向け） |
+
+## レスポンス（例）
+
+`200` — 欠席除外が反映され、更新後のグループ情報を返す
+
+```json
+{
+  "status": "updated",
+  "lunchId": "LUNCH-20260428",
+  "removedMemberSlackUserId": "U12345678",
+  "alreadyAbsent": false,
+  "group": {
+    "groupId": "GROUP-01",
+    "members": ["U23456789", "U34567890", "U45678901"]
+  },
+  "slackNotification": {
+    "updated": true,
+    "messageTs": "1714261200.123456"
+  }
+}
+```
+
+`alreadyAbsent: true` の場合は、対象メンバーが既に除外済みであるため状態変更なし。
+
+## エラー
+
+| HTTP | 条件 |
+| ---- | ---- |
+| `400` | 不正なリクエスト（必須欠落、型不正） |
+| `403` | 対象ランチの参加者ではない |
+| `404` | 対象ランチまたは対象メンバーが存在しない |
+| `409` | 既に最終確定済みで欠席変更不可 |
+| `500` | DB または Slack 更新処理で失敗 |
+
+## 関連
+
+- ユーザーストーリー: [US-004](../../user-stories/us-004.md)
+- OpenAPI: [`openapi-app.yml`](../../../../public/openapi/openapi-app.yml)

--- a/docs/specs/docs/ja/1.0.0/user-stories/us-004.md
+++ b/docs/specs/docs/ja/1.0.0/user-stories/us-004.md
@@ -60,3 +60,10 @@ notes:
 ## 補足
 
 <UserStoryPage section="notes" />
+
+## Application Design トレース
+
+| 区分 | 参照 |
+| ---- | ---- |
+| API（欠席登録） | [postGroupAbsence](../api/design/postGroupAbsence.md) / `operationId: postGroupAbsence` |
+| OpenAPI | [`openapi-app.yml`](../../../public/openapi/openapi-app.yml) |

--- a/docs/specs/docs/public/openapi/openapi-app.yml
+++ b/docs/specs/docs/public/openapi/openapi-app.yml
@@ -3,7 +3,61 @@ info:
   title: Luncher API
   version: 1.0.0
 components:
-  schemas: {}
+  schemas:
+    PostGroupAbsenceRequest:
+      type: object
+      properties:
+        memberSlackUserId:
+          type: string
+        triggerMessageTs:
+          type: string
+        reason:
+          type: string
+      required:
+        - memberSlackUserId
+        - triggerMessageTs
+    PostGroupAbsenceResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - updated
+        lunchId:
+          type: string
+        removedMemberSlackUserId:
+          type: string
+        alreadyAbsent:
+          type: boolean
+        group:
+          type: object
+          properties:
+            groupId:
+              type: string
+            members:
+              type: array
+              items:
+                type: string
+          required:
+            - groupId
+            - members
+        slackNotification:
+          type: object
+          properties:
+            updated:
+              type: boolean
+            messageTs:
+              type: string
+          required:
+            - updated
+            - messageTs
+      required:
+        - status
+        - lunchId
+        - removedMemberSlackUserId
+        - alreadyAbsent
+        - group
+        - slackNotification
   parameters: {}
 paths:
   /health:
@@ -25,4 +79,38 @@ paths:
                       - ok
                 required:
                   - status
+  /lunches/{lunchId}/groups/absence:
+    post:
+      operationId: postGroupAbsence
+      tags:
+        - lunch-group
+      parameters:
+        - name: lunchId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PostGroupAbsenceRequest'
+      responses:
+        "200":
+          description: Group member was removed from matched group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostGroupAbsenceResponse'
+        "400":
+          description: Invalid request
+        "403":
+          description: Forbidden for non-participant
+        "404":
+          description: Lunch or member not found
+        "409":
+          description: Lunch state does not allow update
+        "500":
+          description: Internal server error
 webhooks: {}


### PR DESCRIPTION
## Summary
- US-004（割当後の欠席）向けの API 補足 `postGroupAbsence` を `api/design` に追加
- `openapi-app.yml` に `POST /lunches/{lunchId}/groups/absence` と関連 schema を追加して operationId を整合
- `us-004.md` に Application Design トレースを追記し、設計参照を明示

## Test plan
- [x] ドキュメント整合を目視確認
- [x] `operationId` と API 設計ファイル名の対応を確認

Made with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)