### PR TITLE
chore(commitlint): enforce kebab-case single-token scope

### DIFF
--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -636,3 +636,12 @@
 **Context**: INCEPTION - API設計テンプレートのセクション構造統一（見出し完全一致・内容で「なし」表現）
 
 ---
+
+## commitlint scope 厳格化（CI commit-check との整合）
+
+**Timestamp**: 2026-04-30T02:30:00+09:00
+**User Input**: "main から、先程 commit-check がエラーになったことへの対策をしたい。feat(api,docs) みたいなのを作らないようにチェックの実装を修正する必要がある。 / conventional branch でも同じ scope のチェックを入れたい / C"
+**AI Response**: "`commitlint.config.cjs` に `scope-case: kebab-case` と、カスタムプラグイン `scope-no-multiple`（scope 内に `,` `/` 空白を含むコミットを拒否）を追加。`feat(api,docs):` `feat(api/docs):` `feat(api docs):` `feat(API):` `feat(api,):` を NG として検出することをローカル CLI で確認。`feat(api):` `feat(api-docs):` `feat:` `fix(my-scope):` は引き続き通過。Conventional Branch 側は既に branch-name-guard が `,` や大文字を弾く構成のため変更なし（案 C）。"
+**Context**: Governance - commit message validation（CI commit-check-action とローカル commit-msg フックの整合）
+
+---

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,36 @@
+/**
+ * Local commitlint configuration.
+ *
+ * In addition to Conventional Commits defaults we enforce:
+ *   - scope-case: kebab-case (rejects e.g. `feat(API): ...`).
+ *   - scope-no-multiple: rejects multi-token scopes such as `feat(api,docs): ...`,
+ *     `feat(api/docs): ...`, or `feat(api docs): ...`. commitlint by itself
+ *     splits these on `,`/`/`/whitespace and accepts each fragment, so the
+ *     CI commit-check-action rejects them while the local hook would not.
+ *     This custom rule keeps the local hook aligned with CI.
+ */
 module.exports = {
-  extends: ["@commitlint/config-conventional"],
+  extends: ['@commitlint/config-conventional'],
+  plugins: [
+    {
+      rules: {
+        'scope-no-multiple': (parsed) => {
+          const header = parsed.header ?? '';
+          const match = header.match(/^[^(]+\(([^)]+)\)/);
+          if (!match) {
+            return [true];
+          }
+          const scope = match[1];
+          if (/[,\/\s]/.test(scope)) {
+            return [false, `scope must be a single token without separators (",", "/", whitespace); got "${scope}"`];
+          }
+          return [true];
+        },
+      },
+    },
+  ],
+  rules: {
+    'scope-case': [2, 'always', 'kebab-case'],
+    'scope-no-multiple': [2, 'always'],
+  },
 };


### PR DESCRIPTION
## 概要

ローカルの `commit-msg` フック (`pnpm commitlint`) と CI の `commit-check/commit-check-action` で commit メッセージ scope の検証強度がずれており、`feat(api,docs): ...` のようなマルチスコープを **ローカルでは通してしまい、CI で初めて弾かれる** という事象が発生していました（直前の PR #108 で実際に発生）。本 PR でローカル側の commitlint 設定を強化し、CI と整合させます。

## 変更内容

`commitlint.config.cjs` に 2 つのルールを追加:

1. **`scope-case: kebab-case`**
   - `feat(API): ...` のような大文字混在 scope を拒否
2. **カスタム `scope-no-multiple` プラグイン**
   - scope 内に `,` `/` 空白を含むコミットを拒否
   - 標準の commitlint は `,` `/` 空白を **複数 scope の区切り** として解釈し、各トークンを個別に検証するため `feat(api,docs):` `feat(api/docs):` を素通りさせてしまう。CI 側の `commit-check-action` はこれらを弾くため、不一致解消のためのカスタムルール

## 動作確認（ローカル `pnpm exec commitlint`）

### 拒否（NG）
| 入力 | 検出ルール |
| --- | --- |
| `feat(api,docs): test` | scope-no-multiple |
| `feat(api/docs): test` | scope-no-multiple |
| `feat(api docs): test` | scope-case + scope-no-multiple |
| `feat(API): test` | scope-case |
| `feat(api,): test` | scope-no-multiple |

### 通過（OK）
| 入力 |
| --- |
| `feat(api): test` |
| `feat(api-docs): test` |
| `feat: test` |
| `fix(my-scope): bug` |

## Conventional Branch 側

branch-name-guard / branch-create-guard の現行 pattern は既に `,` `/` 大文字を弾く構成のため、追加変更は不要（オプション C を選択）。

## 影響

- 既存の commit/PR は対象外（過去の commit は再検証されない）
- 今後のローカルコミット時、`commit-msg` フックで弾けるようになるため、CI 失敗 → 再 push の手戻りが減る


Made with [Cursor](https://cursor.com)