### PR TITLE
fix(hooks): prevent option tokens from branch-name checks

### DIFF
--- a/.cursor/hooks/enforce-conventional-branch.sh
+++ b/.cursor/hooks/enforce-conventional-branch.sh
@@ -25,7 +25,7 @@ let branchName = "";
 
 const checkout = commandText.match(/\bgit checkout -b\s+(\S+)/);
 const sw = commandText.match(/\bgit switch -c\s+(\S+)/);
-const branch = commandText.match(/\bgit branch\s+(?:-f|--force\s+)?(\S+)/);
+const branch = commandText.match(/\bgit branch\s+(?:-f\s+|--force\s+)?((?!-)\S+)/);
 const gh = commandText.match(/\bgh issue develop\b.*\s--name\s+(\S+)/);
 
 if (checkout) branchName = checkout[1];

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -771,3 +771,12 @@
 **Context**: Construction - glossary データ参照仕様の統一（version 優先フォールバック）
 
 ---
+
+## Conventional Branch フック: branch サブコマンド判定の誤爆修正
+
+**Timestamp**: 2026-04-30T04:37:00+09:00
+**User Input**: "その３つだけが対象になるように修正"
+**AI Response**: "`.cursor/hooks/enforce-conventional-branch.sh` の抽出正規表現を修正。`checkout -b` / `switch -c` / `branch <name>`（`-f|--force` 可）だけを対象にし、先頭 `-` の引数はブランチ名として扱わないように変更。これにより list/delete 系オプションの誤検知を防止。"
+**Context**: Governance - Branch name guard の対象コマンド限定と誤検知防止
+
+---


### PR DESCRIPTION
## Summary
- Start from latest `main` and apply only the hook parsing fix
- Update conventional-branch extraction so `git branch` option tokens are not treated as branch names
- Keep audit entry aligned with the fix

## Test plan
- [x] pre-push `turbo run test`


Made with [Cursor](https://cursor.com)