### PR TITLE
chore(rules): add deprecation avoidance policy

### DIFF
--- a/.cursor/rules/project-standards.mdc
+++ b/.cursor/rules/project-standards.mdc
@@ -79,3 +79,9 @@ alwaysApply: true
 
 - Script execution runtime MUST be Node.js. Prefer `node` or `tsx`-based scripts for automation and hooks.
 - Do NOT introduce new Python-based scripts or Python runtime dependencies for project automation/hooks unless explicitly requested by the user.
+
+## 13) Deprecation Avoidance Policy
+
+- When writing or updating code, **NEVER** introduce deprecated APIs/methods/types if a supported alternative exists.
+- If existing code uses deprecated APIs, prefer migrating touched lines to the recommended replacement within the same task when safely possible.
+- If migration scope is large or risky, call it out explicitly and propose a follow-up change instead of adding new deprecated usage.


### PR DESCRIPTION
## Summary
- `project-standards` に Deprecated API の新規導入を禁止する運用ルールを追加
- 既存 deprecated 利用については、触る行は可能な範囲で移行し、大規模な場合はフォローアップ提案を明記する方針を追記

## Test plan
- [x] pre-commit hooks passed
- [x] commit-msg hook passed
- [x] pre-push hook passed

Made with [Cursor](https://cursor.com)